### PR TITLE
Avoid duplicate installation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,10 +2,8 @@
     "name": "eightwire/magento2-module-noreservations",
     "description": "",
     "require": {
-        "magento/magento-composer-installer": "*",
         "magento/module-inventory": "^1.0",
         "magento/module-inventory-shipping": "^1.0"
-
     },
     "type": "magento2-module",
     "license": [
@@ -19,13 +17,5 @@
         "psr-4": {
             "EightWire\\NoReservations\\": ""
         }
-    },
-    "extra": {
-        "map": [
-            [
-                "*",
-                "EightWire/NoReservations"
-            ]
-        ]
     }
 }


### PR DESCRIPTION
# Issue
This module is currently configured to copy all its files from `vendor/` to `app/code/`.

## Steps to reproduce
1. Install this module with `composer require eightwire/magento2-module-noreservations`
1. Run `bin/magento setup:di:compile`

## Expected result
- Files for this module are found in `vendor/eightwire/magento2-module-noreservations/`.
- No error from `bin/magento setup:di:compile`

## Actual result
- Files for this module are found in `vendor/eightwire/magento2-module-noreservations/` and `app/code/EightWire/NoReservations/`.
- `bin/magento setup:di:compile` fails with an error: `Autoload error: Module 'EightWire_NoReservations' from '/var/www/html/app/code/EightWire/NoReservations' has been already defined in '/var/www/html/vendor/eightwire/magento2-module-noreservations'.`